### PR TITLE
Fix folder name after clone SpinalBaseProject

### DIFF
--- a/spinal/getting_started.md
+++ b/spinal/getting_started.md
@@ -45,7 +45,7 @@ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823
 sudo apt-get update
 sudo apt-get install sbt
 git clone https://github.com/SpinalHDL/SpinalTemplateSbt.git
-cd SpinalBaseProject/
+cd SpinalTemplateSbt/
 sbt run
 ls MyTopLevel.vhd
 ```


### PR DESCRIPTION
Git reference has been update in 95ab3d9f92dc06f4795517fceb84b7c05b7e0db0, but "cd" command to cloned git repo not. This commit update "cd" command to new name of git repo