### PR TITLE
fix 404 url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 This is the host of the documentation for the [*SpinalHDL* language](https://github.com/SpinalHDL) user guide. 
 
-# [Head for the documentation website](http://spinalhdl.github.io/SpinalDoc)
+# [Head for the documentation website](https://spinalhdl.github.io/SpinalDoc-RTD/)


### PR DESCRIPTION
The link in README.md is down, just fix it.